### PR TITLE
Throw illegal argument exception on receiving null text String.

### DIFF
--- a/ports/java/java/src/main/java/com/mzsanford/cld/CompactLanguageDetector.java
+++ b/ports/java/java/src/main/java/com/mzsanford/cld/CompactLanguageDetector.java
@@ -19,6 +19,9 @@ public class CompactLanguageDetector {
      * @return result object with identification details
      */    
     public LanguageDetectionResult detect(String text) {
+        if (text == null) {
+          throw new IllegalArgumentException("Text cannot be null.");
+        }
         // Native call.
         LanguageDetectionResult result = detectLanguageDetails(text, true, true, false, true, null);
         return result;


### PR DESCRIPTION
Otherwise this crashes the JVM! At least when running in JRuby.

Can be handled in a different way if you choose, but was highly annoying running into this.
