### PR TITLE
Update pom.xml

### DIFF
--- a/ports/java/native/unix/pom.xml
+++ b/ports/java/native/unix/pom.xml
@@ -39,7 +39,7 @@
           </sources>
           <compilerStartOptions>
             <!-- TODO: Get /usr/local/include/cld from pkg-config -->
-            <compilerStartOption>-c -DCLD_WINDOWS -I${env.JAVA_HOME}/include/linux -I/usr/local/include/cld </compilerStartOption>
+            <compilerStartOption>-c -fPIC -DCLD_WINDOWS -I${env.JAVA_HOME}/include/linux -I/usr/local/include/cld </compilerStartOption>
           </compilerStartOptions>
           <linkerStartOptions>
             <!-- TODO: Get /usr/local/lib/cld from pkg-config -->


### PR DESCRIPTION
Fix relocation R_X86_64_32 against `.rodata' can not be used when making a shared object when install java plugin on Centos 6 x86_64