### PR TITLE
Return null candidates instead of error in getCandidates()

### DIFF
--- a/ports/java/java/src/main/java/com/mzsanford/cld/LanguageDetectionResult.java
+++ b/ports/java/java/src/main/java/com/mzsanford/cld/LanguageDetectionResult.java
@@ -48,6 +48,7 @@ public class LanguageDetectionResult {
      */
     public List<LanguageDetectionCandidate> getCandidates() {
         // Take the hit for a copy to prevent changes.
+        if (candidates == null) return null;
         return Collections.unmodifiableList(candidates);
     }
 


### PR DESCRIPTION
If no candidates were returned at all, getCandidates() will return a NullPointerException inside Collections.unmodifiableCollection.
This checks beforehand whether it is null or not